### PR TITLE
bump 1.3.4

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-packer_version: 1.3.3
+packer_version: 1.3.4
 packer_dist_file: "packer_{{ packer_version }}_linux_amd64.zip"
 packer_download_url: "https://releases.hashicorp.com/packer/{{ packer_version }}/{{ packer_dist_file }}"
 packer_tmp_download_dir: "/tmp/ansible-role-hashicorp-packer"


### PR DESCRIPTION
the 1.3.3 version give an 403 error!, correcting to the current build.